### PR TITLE
Update client to 0.0.5 (custom startPoint)

### DIFF
--- a/cjs-cli/package.json
+++ b/cjs-cli/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "UNLICENSED",
   "dependencies": {
-    "@mister-webhooks/client": "^0.0.4",
+    "@mister-webhooks/client": "^0.0.5",
     "commander": "^14.0.0"
   }
 }

--- a/esm-cli/package.json
+++ b/esm-cli/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx main.ts"
   },
   "dependencies": {
-    "@mister-webhooks/client": "0.0.4-beta.1",
+    "@mister-webhooks/client": "^0.0.5",
     "meow": "^13.2.0",
     "zod": "^3.25.42"
   },

--- a/esm-cli/package.json
+++ b/esm-cli/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx main.ts"
   },
   "dependencies": {
-    "@mister-webhooks/client": "0.0.4",
+    "@mister-webhooks/client": "0.0.4-beta.1",
     "meow": "^13.2.0",
     "zod": "^3.25.42"
   },


### PR DESCRIPTION
examples of valid -o options:

```
npm run dev --  -t incoming.djfjeutgfrbfmspiejmmt.zzuohyuenixuzwfrqbptz -f ./boon-dev-postmark.json -o 2024-01-01

npm run dev --  -t incoming.djfjeutgfrbfmspiejmmt.zzuohyuenixuzwfrqbptz -f ./boon-dev-postmark.json -o EARLIEST

npm run dev --  -t incoming.djfjeutgfrbfmspiejmmt.zzuohyuenixuzwfrqbptz -f ./boon-dev-postmark.json -o 2025-06-17T19:19:34.842Z
```

I think this works ok. 

If you try to supply -o with a running consumer, you get an error (per the kafkajs docs). I'm not sure how we want to handle this or describe it to users... 